### PR TITLE
Feature/immutable record default values

### DIFF
--- a/src/Data/ImmutableRecord.php
+++ b/src/Data/ImmutableRecord.php
@@ -10,12 +10,12 @@ interface ImmutableRecord
      *
      * @return string
      */
-    public static function type(): string;
+    public static function __type(): string;
 
     /**
      * @return array JSON Schema of the type
      */
-    public static function schema(): array;
+    public static function __schema(): array;
 
     /**
      * @param array $recordData

--- a/src/Data/ImmutableRecordLogic.php
+++ b/src/Data/ImmutableRecordLogic.php
@@ -18,12 +18,12 @@ trait ImmutableRecordLogic
      */
     private static $__schema;
 
-    public static function type(): string
+    public static function __type(): string
     {
         return self::convertClassToTypeName(get_called_class());
     }
 
-    public static function schema(): array
+    public static function __schema(): array
     {
         return self::generateSchemaFromPropTypeMap();
     }
@@ -375,7 +375,7 @@ trait ImmutableRecordLogic
         $refObj = new \ReflectionClass($classOrType);
 
         if($refObj->implementsInterface(ImmutableRecord::class)) {
-            return call_user_func([$classOrType, 'type']);
+            return call_user_func([$classOrType, '__type']);
         }
 
         return self::convertClassToTypeName($classOrType);

--- a/src/EventMachine.php
+++ b/src/EventMachine.php
@@ -315,8 +315,8 @@ final class EventMachine
                 throw new \InvalidArgumentException("Invalid type given. $nameOrImmutableRecordClass does not implement " . ImmutableRecord::class);
             }
 
-            $name = call_user_func([$nameOrImmutableRecordClass, 'type']);
-            $schema = call_user_func([$nameOrImmutableRecordClass, 'schema']);
+            $name = call_user_func([$nameOrImmutableRecordClass, '__type']);
+            $schema = call_user_func([$nameOrImmutableRecordClass, '__schema']);
         } else {
             $name = $nameOrImmutableRecordClass;
         }

--- a/tests/Data/ImmutableRecordTest.php
+++ b/tests/Data/ImmutableRecordTest.php
@@ -91,7 +91,7 @@ final class ImmutableRecordTest extends TestCase
      */
     public function it_uses_short_class_name_as_type()
     {
-        self::assertEquals('TestProduct', TestProduct::type());
+        self::assertEquals('TestProduct', TestProduct::__type());
     }
 
     /**
@@ -108,7 +108,7 @@ final class ImmutableRecordTest extends TestCase
             'tags' => JsonSchema::array(JsonSchema::string()),
         ]);
 
-        self::assertEquals($expectedSchema, TestProduct::schema());
+        self::assertEquals($expectedSchema, TestProduct::__schema());
     }
 
     /**
@@ -123,7 +123,7 @@ final class ImmutableRecordTest extends TestCase
             'identities' => JsonSchema::array(JsonSchema::typeRef('TestIdentityVO')),
         ]);
 
-        self::assertEquals($expectedSchema, TestUserVO::schema());
+        self::assertEquals($expectedSchema, TestUserVO::__schema());
     }
 
     /**

--- a/tests/Data/ImmutableRecordTest.php
+++ b/tests/Data/ImmutableRecordTest.php
@@ -6,6 +6,7 @@ namespace Prooph\EventMachineTest\Data;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Util\Json;
 use Prooph\EventMachine\JsonSchema\JsonSchema;
+use Prooph\EventMachineTest\Data\Stubs\TestBuildingVO;
 use Prooph\EventMachineTest\Data\Stubs\TestCommentVO;
 use Prooph\EventMachineTest\Data\Stubs\TestIdentityVO;
 use Prooph\EventMachineTest\Data\Stubs\TestProduct;
@@ -159,5 +160,15 @@ final class ImmutableRecordTest extends TestCase
         $testComment = TestCommentVO::fromArray($data);
 
         $this->assertEquals($data, $testComment->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function it_uses_default_value_if_val_is_not_passed_to_constructor()
+    {
+        $testBuilding = TestBuildingVO::fromArray(['name' => 'My House']);
+
+        $this->assertEquals(['name' => 'My House', 'type' => 'house'], $testBuilding->toArray());
     }
 }

--- a/tests/Data/Stubs/TestBuildingVO.php
+++ b/tests/Data/Stubs/TestBuildingVO.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Prooph\EventMachineTest\Data\Stubs;
+
+use Prooph\EventMachine\Data\ImmutableRecord;
+use Prooph\EventMachine\Data\ImmutableRecordLogic;
+
+final class TestBuildingVO implements ImmutableRecord
+{
+    use ImmutableRecordLogic;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $buildingType = 'house';
+
+    /**
+     * @return string
+     */
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function __type(): string
+    {
+        return $this->type;
+    }
+}

--- a/tests/Data/Stubs/TestBuildingVO.php
+++ b/tests/Data/Stubs/TestBuildingVO.php
@@ -18,7 +18,7 @@ final class TestBuildingVO implements ImmutableRecord
     /**
      * @var string
      */
-    private $buildingType = 'house';
+    private $type = 'house';
 
     /**
      * @return string
@@ -31,7 +31,7 @@ final class TestBuildingVO implements ImmutableRecord
     /**
      * @return string
      */
-    public function __type(): string
+    public function type(): string
     {
         return $this->type;
     }

--- a/tests/Data/Stubs/TestProduct.php
+++ b/tests/Data/Stubs/TestProduct.php
@@ -42,7 +42,7 @@ final class TestProduct implements ImmutableRecord
      */
     private $tags;
 
-    public static function schema(): array
+    public static function __schema(): array
     {
         return self::generateSchemaFromPropTypeMap(['tags' => JsonSchema::TYPE_STRING]);
     }

--- a/tests/Data/Stubs/TestUserVO.php
+++ b/tests/Data/Stubs/TestUserVO.php
@@ -30,7 +30,7 @@ final class TestUserVO implements ImmutableRecord
      */
     private $identities;
 
-    public static function schema(): array
+    public static function __schema(): array
     {
         return self::generateSchemaFromPropTypeMap(['identities' => TestIdentityVO::class]);
     }

--- a/tests/EventMachineTest.php
+++ b/tests/EventMachineTest.php
@@ -682,7 +682,7 @@ class EventMachineTest extends BasicTestCase
         $this->expectExceptionMessageRegExp('/Validation of UserIdentityData failed: \[identity.password\] Integer value found, but a string is required/');
 
         $this->eventMachine->jsonSchemaAssertion()->assert('UserIdentityData', $userIdentityData, JsonSchema::object([
-            'identity' => JsonSchema::typeRef(TestIdentityVO::type())
+            'identity' => JsonSchema::typeRef(TestIdentityVO::__type())
         ]));
     }
 


### PR DESCRIPTION
This PR only adds a test to cover that default values are considered when validating an immutable record.

But the PR also introduces a BC break because methods to fetch meta information from an immutable record are renamed from `type` to `__type` and `schema` to `__schema`