### PR TITLE
Build the message box schema to support doc generation

### DIFF
--- a/docs/tutorial/bonus_I.md
+++ b/docs/tutorial/bonus_I.md
@@ -417,7 +417,7 @@ class Query implements EventMachineDescription
             JsonSchema::object(['name' => Schema::username()])
         )
             ->resolveWith(UserBuildingFinder::class)
-            ->returnType(Schema::userBuilding());
+            ->setReturnType(Schema::userBuilding());
     }
 }
 

--- a/docs/tutorial/part_IV.md
+++ b/docs/tutorial/part_IV.md
@@ -165,13 +165,13 @@ class Query implements EventMachineDescription
         //Default query: can be used to check if service is up and running
         $eventMachine->registerQuery(self::HEALTH_CHECK) //<-- Payload schema is optional for queries
             ->resolveWith(HealthCheckResolver::class) //<-- Service id (usually FQCN) to get resolver from DI container
-            ->returnType(Schema::healthCheck()); //<-- Type returned by resolver, this is converted to a GraphQL type
+            ->setReturnType(Schema::healthCheck()); //<-- Type returned by resolver, this is converted to a GraphQL type
 
         $eventMachine->registerQuery(self::BUILDING, JsonSchema::object([
             'buildingId' => JsonSchema::uuid(),
         ]))
             ->resolveWith(/* ??? */)
-            ->returnType(JsonSchema::typeRef(Aggregate::BUILDING));
+            ->setReturnType(JsonSchema::typeRef(Aggregate::BUILDING));
     }
 }
 
@@ -371,7 +371,7 @@ class Query implements EventMachineDescription
             'buildingId' => JsonSchema::uuid(),
         ]))
             ->resolveWith(BuildingFinder::class) //<-- Finder service id
-            ->returnType(JsonSchema::typeRef(Aggregate::BUILDING));
+            ->setReturnType(JsonSchema::typeRef(Aggregate::BUILDING));
     }
 }
 
@@ -438,7 +438,7 @@ class Query implements EventMachineDescription
             'buildingId' => JsonSchema::uuid(),
         ]))
             ->resolveWith(BuildingFinder::class)
-            ->returnType(JsonSchema::typeRef(Aggregate::BUILDING));
+            ->setReturnType(JsonSchema::typeRef(Aggregate::BUILDING));
 
         //New query
         $eventMachine->registerQuery(
@@ -452,7 +452,7 @@ class Query implements EventMachineDescription
             //Resolve query with same finder ...
             ->resolveWith(BuildingFinder::class)
             //... but return an array of Building type
-            ->returnType(JsonSchema::array(
+            ->setReturnType(JsonSchema::array(
                 JsonSchema::typeRef(Aggregate::BUILDING)
             ));
     }

--- a/docs/tutorial/part_V.md
+++ b/docs/tutorial/part_V.md
@@ -133,13 +133,13 @@ class Query implements EventMachineDescription
         //Default query: can be used to check if service is up and running
         $eventMachine->registerQuery(self::HEALTH_CHECK) //<-- Payload schema is optional for queries
             ->resolveWith(HealthCheckResolver::class) //<-- Service id (usually FQCN) to get resolver from DI container
-            ->returnType(Schema::healthCheck()); //<-- Type returned by resolver, this is converted to a GraphQL type
+            ->setReturnType(Schema::healthCheck()); //<-- Type returned by resolver, this is converted to a GraphQL type
 
         $eventMachine->registerQuery(self::BUILDING, JsonSchema::object([
             Payload::BUILDING_ID => JsonSchema::uuid(),
         ]))
             ->resolveWith(BuildingFinder::class)
-            ->returnType(JsonSchema::typeRef(Aggregate::BUILDING));
+            ->setReturnType(JsonSchema::typeRef(Aggregate::BUILDING));
 
         $eventMachine->registerQuery(
             self::BUILDINGS,
@@ -149,7 +149,7 @@ class Query implements EventMachineDescription
             )
         )
             ->resolveWith(BuildingFinder::class)
-            ->returnType(JsonSchema::array(
+            ->setReturnType(JsonSchema::array(
                 JsonSchema::typeRef(Aggregate::BUILDING)
             ));
     }
@@ -380,13 +380,13 @@ class Query implements EventMachineDescription
         //Default query: can be used to check if service is up and running
         $eventMachine->registerQuery(self::HEALTH_CHECK) //<-- Payload schema is optional for queries
             ->resolveWith(HealthCheckResolver::class) //<-- Service id (usually FQCN) to get resolver from DI container
-            ->returnType(Schema::healthCheck()); //<-- Type returned by resolver, this is converted to a GraphQL type
+            ->setReturnType(Schema::healthCheck()); //<-- Type returned by resolver, this is converted to a GraphQL type
 
         $eventMachine->registerQuery(self::BUILDING, JsonSchema::object([
             Payload::BUILDING_ID => Schema::buildingId(),
         ]))
             ->resolveWith(BuildingFinder::class)
-            ->returnType(Schema::building());
+            ->setReturnType(Schema::building());
 
         $eventMachine->registerQuery(
             self::BUILDINGS,
@@ -396,7 +396,7 @@ class Query implements EventMachineDescription
             )
         )
             ->resolveWith(BuildingFinder::class)
-            ->returnType(Schema::buildingList());
+            ->setReturnType(Schema::buildingList());
     }
 }
 

--- a/examples/Messaging/MessageDescription.php
+++ b/examples/Messaging/MessageDescription.php
@@ -79,16 +79,16 @@ final class MessageDescription implements EventMachineDescription
             UserDescription::IDENTIFIER => $userId,
         ]))
         ->resolveWith(GetUserResolver::class)
-        ->returnType(JsonSchema::typeRef('User'));
+        ->setReturnType(JsonSchema::typeRef('User'));
 
         $eventMachine->registerQuery(Query::GET_USERS)
             ->resolveWith(GetUsersResolver::class)
-            ->returnType(JsonSchema::array(JsonSchema::typeRef('User')));
+            ->setReturnType(JsonSchema::array(JsonSchema::typeRef('User')));
 
         $eventMachine->registerQuery(Query::GET_FILTERED_USERS, JsonSchema::object([], [
             'filter' => JsonSchema::nullOr(JsonSchema::string()),
         ]))
             ->resolveWith(GetUsersResolver::class)
-            ->returnType(JsonSchema::array(JsonSchema::typeRef('User')));
+            ->setReturnType(JsonSchema::array(JsonSchema::typeRef('User')));
     }
 }

--- a/src/EventMachine.php
+++ b/src/EventMachine.php
@@ -767,7 +767,7 @@ final class EventMachine
         foreach ($this->queryMap as $queryName => $map) {
             $description = $this->queryDescriptions[$queryName];
 
-            $map['response'] = $description->getReturnType();
+            $map['response'] = $description->returnType();
 
             $querySchemas[$queryName] = $map;
         }

--- a/src/EventMachine.php
+++ b/src/EventMachine.php
@@ -39,9 +39,9 @@ use Prooph\EventMachine\Http\MessageBox;
 use Prooph\EventMachine\JsonSchema\JsonSchema;
 use Prooph\EventMachine\JsonSchema\JsonSchemaAssertion;
 use Prooph\EventMachine\JsonSchema\JustinRainbowJsonSchemaAssertion;
+use Prooph\EventMachine\JsonSchema\Type;
 use Prooph\EventMachine\JsonSchema\Type\EnumType;
 use Prooph\EventMachine\JsonSchema\Type\ObjectType;
-use Prooph\EventMachine\JsonSchema\Type;
 use Prooph\EventMachine\Messaging\GenericJsonSchemaMessageFactory;
 use Prooph\EventMachine\Persistence\Stream;
 use Prooph\EventMachine\Projecting\ProjectionDescription;
@@ -310,15 +310,6 @@ final class EventMachine
         $this->queryDescriptions[$queryName] = $queryDesc;
 
         return $queryDesc;
-    }
-
-    public function registerQueryResponse(string $queryName, Type $responseType): void
-    {
-        if (!$this->isKnownQuery($queryName)) {
-            throw new \RuntimeException("Query $queryName has not been registered");
-        }
-
-        $this->queryMap[$queryName]['response'] = $responseType->toArray();
     }
 
     public function registerProjection(string $projectionName, ProjectionDescription $projectionDescription): void

--- a/src/GraphQL/TypeLanguage.php
+++ b/src/GraphQL/TypeLanguage.php
@@ -94,7 +94,7 @@ final class TypeLanguage
 
             $typeLanguage .= "  $queryName";
 
-            if (!empty($payload['properties'])) {
+            if (! empty($payload['properties'])) {
                 $typeLanguage .= self::convertPayloadToArguments($queryName, $payload, $AST);
             }
 

--- a/src/GraphQL/TypeLanguage.php
+++ b/src/GraphQL/TypeLanguage.php
@@ -94,7 +94,7 @@ final class TypeLanguage
 
             $typeLanguage .= "  $queryName";
 
-            if ($payload) {
+            if (!empty($payload['properties'])) {
                 $typeLanguage .= self::convertPayloadToArguments($queryName, $payload, $AST);
             }
 

--- a/src/Querying/QueryDescription.php
+++ b/src/Querying/QueryDescription.php
@@ -66,7 +66,7 @@ final class QueryDescription
         return $this;
     }
 
-    public function returnType(Type $typeSchema): self
+    public function setReturnType(Type $typeSchema): self
     {
         $typeSchema = $typeSchema->toArray();
         $this->eventMachine->jsonSchemaAssertion()->assert("Query return type {$this->queryName}", $typeSchema, JsonSchema::metaSchema());
@@ -76,7 +76,7 @@ final class QueryDescription
         return $this;
     }
 
-    public function getReturnType(): ?array
+    public function returnType(): ?array
     {
         return $this->returnType;
     }

--- a/src/Querying/QueryDescription.php
+++ b/src/Querying/QueryDescription.php
@@ -91,6 +91,7 @@ final class QueryDescription
     {
         return $this->returnType;
     }
+
     private function assertResolverAndReturnTypeAreSet(): void
     {
         if (! $this->resolver) {

--- a/src/Querying/QueryDescription.php
+++ b/src/Querying/QueryDescription.php
@@ -33,11 +33,6 @@ final class QueryDescription
     private $resolver;
 
     /**
-     * @var int|null
-     */
-    private $queryComplexity;
-
-    /**
      * @var array
      */
     private $returnType;
@@ -55,7 +50,6 @@ final class QueryDescription
         return [
             'name' => $this->queryName,
             'resolver' => $this->resolver,
-            'complexity' => $this->queryComplexity,
             'returnType' => $this->returnType,
         ];
     }
@@ -70,11 +64,6 @@ final class QueryDescription
         $this->resolver = $resolver;
 
         return $this;
-    }
-
-    public function queryComplexity(int $complexity): self
-    {
-        $this->queryComplexity = $complexity;
     }
 
     public function returnType(Type $typeSchema): self

--- a/src/Querying/QueryDescription.php
+++ b/src/Querying/QueryDescription.php
@@ -87,6 +87,10 @@ final class QueryDescription
         return $this;
     }
 
+    public function getReturnType(): ?array
+    {
+        return $this->returnType;
+    }
     private function assertResolverAndReturnTypeAreSet(): void
     {
         if (! $this->resolver) {


### PR DESCRIPTION
This covers the first part of #77 . I'm happy to discuss any thoughts/concerns, so let me know.

This change includes schema annotations, definitions inclusion and
response inclusion when building the message box schema. The end goal is
to support generating documentation for the message box based off of the
available information.