### PR TITLE
Include type definitions in JSON schema validation

### DIFF
--- a/src/EventMachine.php
+++ b/src/EventMachine.php
@@ -668,6 +668,7 @@ final class EventMachine
                 $this->commandMap,
                 $this->eventMap,
                 $this->queryMap,
+                $this->schemaTypes,
                 $this->container->get(self::SERVICE_ID_JSON_SCHEMA_ASSERTION)
             );
         }

--- a/src/Messaging/GenericJsonSchemaMessageFactory.php
+++ b/src/Messaging/GenericJsonSchemaMessageFactory.php
@@ -55,12 +55,20 @@ final class GenericJsonSchemaMessageFactory implements MessageFactory
      */
     private $queryMap = [];
 
-    public function __construct(array $commandMap, array $eventMap, array $queryMap, JsonSchemaAssertion $jsonSchemaAssertion)
+    /**
+     * Map of type definitions used within other json schemas.
+     *
+     * @var array
+     */
+    private $definitions = [];
+
+    public function __construct(array $commandMap, array $eventMap, array $queryMap, array $definitions, JsonSchemaAssertion $jsonSchemaAssertion)
     {
         $this->jsonSchemaAssertion = $jsonSchemaAssertion;
         $this->commandMap = $commandMap;
         $this->eventMap = $eventMap;
         $this->queryMap = $queryMap;
+        $this->definitions = $definitions;
         //@@TODO: Add optional metadata schema that is then used to validate metadata of all messages
     }
 
@@ -103,6 +111,8 @@ final class GenericJsonSchemaMessageFactory implements MessageFactory
         if (null === $payloadSchema && $messageType === DomainMessage::TYPE_QUERY) {
             $payloadSchema = [];
         }
+
+        $payloadSchema['definitions'] = $this->definitions;
 
         $this->jsonSchemaAssertion->assert($messageName, $messageData['payload'], $payloadSchema);
 

--- a/tests/Container/ReflectionBasedContainerTest.php
+++ b/tests/Container/ReflectionBasedContainerTest.php
@@ -147,6 +147,7 @@ final class ReflectionBasedContainerTest extends BasicTestCase
                         $this->appConfig->arrayValue('event_machine.command_map', []),
                         $this->appConfig->arrayValue('event_machine.event_map', []),
                         $this->appConfig->arrayValue('event_machine.query_map', []),
+                        $this->appConfig->arrayValue('event_machine.definitions', []),
                         $this->jsonSchemaAssertion()
                     );
                 });

--- a/tests/Messaging/GenericJsonSchemaMessageFactoryTest.php
+++ b/tests/Messaging/GenericJsonSchemaMessageFactoryTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * This file is part of the proophsoftware/event-machine.
+ * (c) 2017-2018 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventMachineTest\Messaging;
+
+use Prooph\EventMachine\Commanding\GenericJsonSchemaCommand;
+use Prooph\EventMachine\Eventing\GenericJsonSchemaEvent;
+use Prooph\EventMachine\JsonSchema\JsonSchema;
+use Prooph\EventMachine\JsonSchema\JsonSchemaAssertion;
+use Prooph\EventMachine\JsonSchema\JustinRainbowJsonSchemaAssertion;
+use Prooph\EventMachine\Messaging\GenericJsonSchemaMessageFactory;
+use Prooph\EventMachine\Querying\GenericJsonSchemaQuery;
+use Prooph\EventMachineTest\BasicTestCase;
+
+class GenericJsonSchemaMessageFactoryTest extends BasicTestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_build_command_messages()
+    {
+        $createUserCommand = JsonSchema::object([
+            'name' => JsonSchema::string(),
+        ])->toArray();
+
+        $commands = ['CreateUser' => $createUserCommand];
+
+        $factory = new GenericJsonSchemaMessageFactory($commands, [], [], [], new JustinRainbowJsonSchemaAssertion());
+
+        $message = $factory->createMessageFromArray('CreateUser', ['payload' => ['name' => 'John']]);
+
+        $this->assertInstanceOf(GenericJsonSchemaCommand::class, $message);
+        $this->assertEquals('John', $message->get('name'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_build_event_messages()
+    {
+        $userCreatedEvent = JsonSchema::object([
+            'name' => JsonSchema::string(),
+        ])->toArray();
+
+        $events = ['UserCreated' => $userCreatedEvent];
+
+        $factory = new GenericJsonSchemaMessageFactory([], $events, [], [], new JustinRainbowJsonSchemaAssertion());
+
+        $message = $factory->createMessageFromArray('UserCreated', ['payload' => ['name' => 'John']]);
+
+        $this->assertInstanceOf(GenericJsonSchemaEvent::class, $message);
+        $this->assertEquals('John', $message->get('name'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_build_query_messages()
+    {
+        $userQuery = JsonSchema::object([
+            'name' => JsonSchema::string(),
+        ])->toArray();
+
+        $queries = ['User' => $userQuery];
+
+        $factory = new GenericJsonSchemaMessageFactory([], [], $queries, [], new JustinRainbowJsonSchemaAssertion());
+
+        $message = $factory->createMessageFromArray('User', ['payload' => ['name' => 'John']]);
+
+        $this->assertInstanceOf(GenericJsonSchemaQuery::class, $message);
+        $this->assertEquals('John', $message->get('name'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_support_schema_type_refs()
+    {
+        $addressType = JsonSchema::object([
+            'street' => JsonSchema::string(),
+        ])->toArray();
+
+        $createUserCommand = JsonSchema::object([
+            'address' => JsonSchema::typeRef('Address'),
+        ])->toArray();
+
+        $commands = ['CreateUser' => $createUserCommand];
+        $definitions = ['Address' => $addressType];
+
+        $factory = new GenericJsonSchemaMessageFactory(
+            $commands,
+            [],
+            [],
+            $definitions,
+            new JustinRainbowJsonSchemaAssertion()
+        );
+
+        $message = $factory->createMessageFromArray('CreateUser', ['payload' => ['address' => ['street' => 'test']]]);
+
+        $this->assertInstanceOf(GenericJsonSchemaCommand::class, $message);
+        $this->assertEquals(['street' => 'test'], $message->get('address'));
+    }
+
+    private function jsonSchemaAssertion(): JsonSchemaAssertion
+    {
+        return new JustinRainbowJsonSchemaAssertion();
+    }
+}


### PR DESCRIPTION
I found this bug while looking through some of the code in regards to the JSON schema validation. Because each schema array only contains the definition for that exact object, if it uses a pointer to another schema (`JsonSchema::typeRef`), then the validation will fail to find the definition. 

I resolved this by including the `definitions` in the schema prior to running the validation. 