### PR TITLE
Feature/command handler service injection

### DIFF
--- a/examples/Aggregate/CachableUserFunction.php
+++ b/examples/Aggregate/CachableUserFunction.php
@@ -77,7 +77,7 @@ final class CachableUserFunction
 
         yield [Event::EXTERNAL_SERVICE_WAS_CALLED, [
             CacheableUserDescription::IDENTIFIER => $user->id,
-            'dataFromExternalService' => $data
+            'dataFromExternalService' => $data,
         ]];
     }
 

--- a/examples/Aggregate/CacheableUserDescription.php
+++ b/examples/Aggregate/CacheableUserDescription.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace ProophExample\Aggregate;
 
 use Prooph\EventMachine\EventMachine;
+use ProophExample\Infrastructure\ExternalServiceClient;
 use ProophExample\Messaging\Command;
 use ProophExample\Messaging\Event;
 
@@ -36,6 +37,7 @@ final class CacheableUserDescription
         self::describeRegisterUser($eventMachine);
         self::describeChangeUsername($eventMachine);
         self::describeDoNothing($eventMachine);
+        self::describeCallExternalService($eventMachine);
     }
 
     private static function describeRegisterUser(EventMachine $eventMachine): void
@@ -68,6 +70,15 @@ final class CacheableUserDescription
             ->handle([CachableUserFunction::class, 'doNothing'])
             ->orRecordThat(Event::USERNAME_WAS_CHANGED)
             ->apply([CachableUserFunction::class, 'whenUsernameWasChanged']);
+    }
+
+    private static function describeCallExternalService(EventMachine $eventMachine): void
+    {
+        $eventMachine->process(Command::CALL_EXTERNAL_SERVICE)
+            ->withExisting(Aggregate::USER)
+            ->handle([CachableUserFunction::class, 'callExternalService'], [ExternalServiceClient::class])
+            ->recordThat(Event::EXTERNAL_SERVICE_WAS_CALLED)
+            ->apply([CachableUserFunction::class, 'whenExternalServiceWasCalled']);
     }
 
     private function __construct()

--- a/examples/Aggregate/UserDescription.php
+++ b/examples/Aggregate/UserDescription.php
@@ -39,6 +39,7 @@ final class UserDescription implements EventMachineDescription
     const IDENTIFIER = 'userId';
     const USERNAME = 'username';
     const EMAIL = 'email';
+    const DATA_FROM_EXTERNAL_SERVICE = 'dataFromExternalService';
 
     const STATE_CLASS = UserState::class;
 

--- a/examples/Infrastructure/ExternalServiceClient.php
+++ b/examples/Infrastructure/ExternalServiceClient.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProophExample\Infrastructure;
+
+final class ExternalServiceClient
+{
+    public function retrieveData(string $userId): array
+    {
+        return [
+            'userId' => $userId,
+            'test' => 'succeeded'
+        ];
+    }
+}

--- a/examples/Infrastructure/ExternalServiceClient.php
+++ b/examples/Infrastructure/ExternalServiceClient.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * This file is part of the proophsoftware/event-machine.
+ * (c) 2017-2018 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 declare(strict_types=1);
 

--- a/examples/Infrastructure/ExternalServiceClient.php
+++ b/examples/Infrastructure/ExternalServiceClient.php
@@ -10,7 +10,7 @@ final class ExternalServiceClient
     {
         return [
             'userId' => $userId,
-            'test' => 'succeeded'
+            'test' => 'succeeded',
         ];
     }
 }

--- a/examples/Messaging/Command.php
+++ b/examples/Messaging/Command.php
@@ -16,6 +16,7 @@ final class Command
     const REGISTER_USER = 'RegisterUser';
     const CHANGE_USERNAME = 'ChangeUsername';
     const DO_NOTHING = 'DoNothing';
+    const CALL_EXTERNAL_SERVICE = 'CallExternalService';
 
     private function __construct()
     {

--- a/examples/Messaging/Event.php
+++ b/examples/Messaging/Event.php
@@ -16,6 +16,7 @@ final class Event
     const USER_WAS_REGISTERED = 'UserWasRegistered';
     const USER_REGISTRATION_FAILED = 'UserRegistrationFailed';
     const USERNAME_WAS_CHANGED = 'UsernameWasChanged';
+    const EXTERNAL_SERVICE_WAS_CALLED = 'ExternalServiceWasCalled';
 
     private function __construct()
     {

--- a/examples/Messaging/MessageDescription.php
+++ b/examples/Messaging/MessageDescription.php
@@ -79,7 +79,7 @@ final class MessageDescription implements EventMachineDescription
 
         $eventMachine->registerEvent(Event::EXTERNAL_SERVICE_WAS_CALLED, JsonSchema::object([
             UserDescription::IDENTIFIER => $userId,
-            'dataFromExternalService' => new ArrayType(new StringType())
+            'dataFromExternalService' => new ArrayType(new StringType()),
         ]));
 
         //Register user state as a Type so that we can reference it as query return type

--- a/examples/Messaging/MessageDescription.php
+++ b/examples/Messaging/MessageDescription.php
@@ -14,6 +14,7 @@ namespace ProophExample\Messaging;
 use Prooph\EventMachine\EventMachine;
 use Prooph\EventMachine\EventMachineDescription;
 use Prooph\EventMachine\JsonSchema\JsonSchema;
+use Prooph\EventMachine\JsonSchema\Type\ArrayType;
 use Prooph\EventMachine\JsonSchema\Type\EmailType;
 use Prooph\EventMachine\JsonSchema\Type\StringType;
 use Prooph\EventMachine\JsonSchema\Type\UuidType;
@@ -61,6 +62,9 @@ final class MessageDescription implements EventMachineDescription
         $eventMachine->registerCommand(Command::DO_NOTHING, JsonSchema::object([
             UserDescription::IDENTIFIER => $userId,
         ]));
+        $eventMachine->registerCommand(Command::CALL_EXTERNAL_SERVICE, JsonSchema::object([
+            UserDescription::IDENTIFIER => $userId,
+        ]));
 
         $eventMachine->registerEvent(Event::USER_WAS_REGISTERED, $userDataSchema);
         $eventMachine->registerEvent(Event::USERNAME_WAS_CHANGED, JsonSchema::object([
@@ -71,6 +75,11 @@ final class MessageDescription implements EventMachineDescription
 
         $eventMachine->registerEvent(Event::USER_REGISTRATION_FAILED, JsonSchema::object([
             UserDescription::IDENTIFIER => $userId,
+        ]));
+
+        $eventMachine->registerEvent(Event::EXTERNAL_SERVICE_WAS_CALLED, JsonSchema::object([
+            UserDescription::IDENTIFIER => $userId,
+            'dataFromExternalService' => new ArrayType(new StringType())
         ]));
 
         //Register user state as a Type so that we can reference it as query return type

--- a/src/Commanding/CommandProcessor.php
+++ b/src/Commanding/CommandProcessor.php
@@ -22,9 +22,15 @@ use Prooph\EventSourcing\Aggregate\AggregateType;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\StreamName;
 use Prooph\SnapshotStore\SnapshotStore;
+use Psr\Container\ContainerInterface;
 
 final class CommandProcessor
 {
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
     /**
      * @var string
      */
@@ -71,6 +77,11 @@ final class CommandProcessor
     private $aggregateFunction;
 
     /**
+     * @var array
+     */
+    private $servicesToInject;
+
+    /**
      * @var MessageFactory
      */
     private $messageFactory;
@@ -91,6 +102,7 @@ final class CommandProcessor
     private $aggregateRepository;
 
     public static function fromDescriptionArrayAndDependencies(
+        ContainerInterface $container,
         array $description,
         MessageFactory $messageFactory,
         EventStore $eventStore,
@@ -117,6 +129,10 @@ final class CommandProcessor
             throw new \InvalidArgumentException('Missing key aggregateFunction in commandProcessorDescription');
         }
 
+        if (! array_key_exists('servicesToInject', $description)) {
+            throw new \InvalidArgumentException('Missing key servicesToInject in commandProcessorDescription');
+        }
+
         if (! array_key_exists('eventRecorderMap', $description)) {
             throw new \InvalidArgumentException('Missing key eventRecorderMap in commandProcessorDescription');
         }
@@ -130,11 +146,13 @@ final class CommandProcessor
         }
 
         return new self(
+            $container,
             $description['commandName'],
             $description['aggregateType'],
             $description['createAggregate'],
             $description['aggregateIdentifier'],
             $description['aggregateFunction'],
+            $description['servicesToInject'],
             $description['eventRecorderMap'],
             $description['eventApplyMap'],
             $description['streamName'],
@@ -146,11 +164,13 @@ final class CommandProcessor
     }
 
     public function __construct(
+        ContainerInterface $container,
         string $commandName,
         string $aggregateType,
         bool $createAggregate,
         string $aggregateIdentifier,
         callable $aggregateFunction,
+        array $servicesToInject,
         array $eventRecorderMap,
         array $eventApplyMap,
         string $streamName,
@@ -159,11 +179,13 @@ final class CommandProcessor
         SnapshotStore $snapshotStore = null,
         ContextProvider $contextProvider = null
     ) {
+        $this->container = $container;
         $this->commandName = $commandName;
         $this->aggregateType = $aggregateType;
         $this->aggregateIdentifier = $aggregateIdentifier;
         $this->createAggregate = $createAggregate;
         $this->aggregateFunction = $aggregateFunction;
+        $this->servicesToInject = $servicesToInject;
         $this->eventRecorderMap = $eventRecorderMap;
         $this->eventApplyMap = $eventApplyMap;
         $this->streamName = $streamName;
@@ -216,7 +238,12 @@ final class CommandProcessor
 
         $arFunc = $this->aggregateFunction;
 
-        $events = $arFunc(...$arFuncArgs);
+        $events = $arFunc(...$arFuncArgs, ...array_map(
+            function($service) {
+                return $this->container->get($service);
+            },
+            $this->servicesToInject
+        ));
 
         if (! $events instanceof \Generator) {
             throw new \InvalidArgumentException(

--- a/src/Commanding/CommandProcessor.php
+++ b/src/Commanding/CommandProcessor.php
@@ -239,7 +239,7 @@ final class CommandProcessor
         $arFunc = $this->aggregateFunction;
 
         $events = $arFunc(...$arFuncArgs, ...array_map(
-            function($service) {
+            function ($service) {
                 return $this->container->get($service);
             },
             $this->servicesToInject

--- a/src/Commanding/CommandProcessorDescription.php
+++ b/src/Commanding/CommandProcessorDescription.php
@@ -46,6 +46,14 @@ final class CommandProcessorDescription
      */
     private $aggregateFunction;
 
+    /**
+     * @var array
+     */
+    private $servicesToInject;
+
+    /**
+     * @var array
+     */
     private $eventRecorderMap = [];
 
     /**
@@ -97,11 +105,12 @@ final class CommandProcessorDescription
         return $this;
     }
 
-    public function handle(callable $aggregateFunction): self
+    public function handle(callable $aggregateFunction, array $servicesToInject = []): self
     {
         $this->assertWithAggregateWasCalled(__METHOD__);
 
         $this->aggregateFunction = $aggregateFunction;
+        $this->servicesToInject = $servicesToInject;
 
         return $this;
     }
@@ -151,6 +160,7 @@ final class CommandProcessorDescription
             'aggregateType' => $this->aggregateType,
             'aggregateIdentifier' => $this->aggregateIdentifier,
             'aggregateFunction' => $this->aggregateFunction,
+            'servicesToInject' => $this->servicesToInject,
             'eventRecorderMap' => $eventRecorderMap,
             'streamName' => $this->eventMachine->writeModelStreamName(),
             'contextProvider' => $this->contextProvider,

--- a/src/Commanding/CommandToProcessorRouter.php
+++ b/src/Commanding/CommandToProcessorRouter.php
@@ -18,9 +18,15 @@ use Prooph\EventStore\EventStore;
 use Prooph\ServiceBus\MessageBus;
 use Prooph\ServiceBus\Plugin\AbstractPlugin;
 use Prooph\SnapshotStore\SnapshotStore;
+use Psr\Container\ContainerInterface;
 
 final class CommandToProcessorRouter extends AbstractPlugin
 {
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
     /**
      * Map with command name being the key and CommandProcessorDescription the value
      *
@@ -54,6 +60,7 @@ final class CommandToProcessorRouter extends AbstractPlugin
     private $snapshotStore;
 
     public function __construct(
+        ContainerInterface $container,
         array $routingMap,
         array $aggregateDescriptions,
         MessageFactory $messageFactory,
@@ -61,6 +68,7 @@ final class CommandToProcessorRouter extends AbstractPlugin
         ContextProviderFactory $providerFactory,
         SnapshotStore $snapshotStore = null
     ) {
+        $this->container = $container;
         $this->routingMap = $routingMap;
         $this->aggregateDescriptions = $aggregateDescriptions;
         $this->messageFactory = $messageFactory;
@@ -107,6 +115,7 @@ final class CommandToProcessorRouter extends AbstractPlugin
         $contextProvider = $processorDesc['contextProvider'] ? $this->contextProviderFactory->build($processorDesc['contextProvider']) : null;
 
         $commandProcessor = CommandProcessor::fromDescriptionArrayAndDependencies(
+            $this->container,
             $processorDesc,
             $this->messageFactory,
             $this->eventStore,

--- a/src/EventMachine.php
+++ b/src/EventMachine.php
@@ -828,6 +828,7 @@ final class EventMachine
         }
 
         $router = new CommandToProcessorRouter(
+            $this->container,
             $this->compiledCommandRouting,
             $this->aggregateDescriptions,
             $this->container->get(self::SERVICE_ID_MESSAGE_FACTORY),

--- a/tests/Commanding/CommandProcessorTest.php
+++ b/tests/Commanding/CommandProcessorTest.php
@@ -378,7 +378,7 @@ final class CommandProcessorTest extends BasicTestCase
         $eventMachine->load(CacheableUserDescription::class);
 
         $container = $this->prophesize(ContainerInterface::class);
-        $container->get(ExternalServiceClient::class)->will(function() {
+        $container->get(ExternalServiceClient::class)->will(function () {
             return new ExternalServiceClient();
         });
 
@@ -445,8 +445,8 @@ final class CommandProcessorTest extends BasicTestCase
             UserDescription::IDENTIFIER => $userId,
             'dataFromExternalService' => [
                 UserDescription::IDENTIFIER => $userId,
-                'test' => 'succeeded'
-            ]
+                'test' => 'succeeded',
+            ],
         ], $event->payload());
     }
 }

--- a/tests/Commanding/CommandProcessorTest.php
+++ b/tests/Commanding/CommandProcessorTest.php
@@ -24,6 +24,7 @@ use Prooph\EventStore\StreamName;
 use ProophExample\Aggregate\Aggregate;
 use ProophExample\Aggregate\CacheableUserDescription;
 use ProophExample\Aggregate\UserDescription;
+use ProophExample\Infrastructure\ExternalServiceClient;
 use ProophExample\Messaging\Command;
 use ProophExample\Messaging\Event;
 use ProophExample\Messaging\MessageDescription;
@@ -64,6 +65,7 @@ final class CommandProcessorTest extends BasicTestCase
         $processorDesc['eventApplyMap'] = $aggregateDescriptions[Aggregate::USER]['eventApplyMap'];
 
         $commandProcessor = CommandProcessor::fromDescriptionArrayAndDependencies(
+            $container->reveal(),
             $processorDesc,
             $this->getMockedEventMessageFactory(),
             $eventStore->reveal()
@@ -147,6 +149,7 @@ final class CommandProcessorTest extends BasicTestCase
         $processorDesc['eventApplyMap'] = $aggregateDescriptions[Aggregate::USER]['eventApplyMap'];
 
         $commandProcessor = CommandProcessor::fromDescriptionArrayAndDependencies(
+            $container->reveal(),
             $processorDesc,
             $this->getMockedEventMessageFactory(),
             $eventStore->reveal()
@@ -203,6 +206,7 @@ final class CommandProcessorTest extends BasicTestCase
         $processorDesc['eventApplyMap'] = $aggregateDescriptions[Aggregate::USER]['eventApplyMap'];
 
         $commandProcessor = CommandProcessor::fromDescriptionArrayAndDependencies(
+            $container->reveal(),
             $processorDesc,
             $this->getMockedEventMessageFactory(),
             $eventStore->reveal()
@@ -288,6 +292,7 @@ final class CommandProcessorTest extends BasicTestCase
         $processorDesc['eventApplyMap'] = $aggregateDescriptions[Aggregate::USER]['eventApplyMap'];
 
         $commandProcessor = CommandProcessor::fromDescriptionArrayAndDependencies(
+            $container->reveal(),
             $processorDesc,
             $this->getMockedEventMessageFactory(),
             $eventStore->reveal()
@@ -340,6 +345,7 @@ final class CommandProcessorTest extends BasicTestCase
         }
 
         $commandProcessor = CommandProcessor::fromDescriptionArrayAndDependencies(
+            $container->reveal(),
             $processorDesc,
             $this->getMockedEventMessageFactory(),
             $eventStore->reveal(),
@@ -358,6 +364,89 @@ final class CommandProcessorTest extends BasicTestCase
         self::assertEquals([
             'id' => 1,
             'context' => ['msg' => 'it works'],
+        ], $event->payload());
+    }
+
+    /**
+     * @test
+     */
+    public function it_injects_defined_services_into_command_handler()
+    {
+        $eventMachine = new EventMachine();
+
+        $eventMachine->load(MessageDescription::class);
+        $eventMachine->load(CacheableUserDescription::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(ExternalServiceClient::class)->will(function() {
+            return new ExternalServiceClient();
+        });
+
+        $eventMachine->initialize($container->reveal());
+
+        $config = $eventMachine->compileCacheableConfig();
+
+        $commandRouting = $config['compiledCommandRouting'];
+        $aggregateDescriptions = $config['aggregateDescriptions'];
+
+        $userId = Uuid::uuid4()->toString();
+
+        $recordedEvents = [];
+
+        $eventStore = $this->prophesize(EventStore::class);
+
+        $eventFactory = $this->getMockedEventMessageFactory();
+
+        $eventStore->load(new StreamName('event_stream'), 1, null, Argument::type(MetadataMatcher::class))
+            ->will(function ($args) use ($userId, $eventFactory) {
+                $event = $eventFactory->createMessageFromArray('UserWasRegistered', [
+                    'payload' => [
+                        UserDescription::IDENTIFIER => $userId,
+                        UserDescription::USERNAME => 'Alex',
+                        UserDescription::EMAIL => 'contact@prooph.de',
+                    ],
+                    'metadata' => [
+                        '_causation_id' => Uuid::uuid4()->toString(),
+                        '_causation_name' => 'RegisterUser',
+                        '_aggregate_version' => 1,
+                        '_aggregate_id' => $userId,
+                        '_aggregate_type' => 'User',
+                    ],
+                ]);
+
+                return new \ArrayIterator([$event]);
+            });
+
+        $eventStore->appendTo(new StreamName('event_stream'), Argument::any())->will(function ($args) use (&$recordedEvents) {
+            $recordedEvents = iterator_to_array($args[1]);
+        });
+
+        $processorDesc = $commandRouting[Command::CALL_EXTERNAL_SERVICE];
+        $processorDesc['eventApplyMap'] = $aggregateDescriptions[Aggregate::USER]['eventApplyMap'];
+
+        $commandProcessor = CommandProcessor::fromDescriptionArrayAndDependencies(
+            $container->reveal(),
+            $processorDesc,
+            $this->getMockedEventMessageFactory(),
+            $eventStore->reveal()
+        );
+
+        $callExternalService = $this->getMockedCommandMessageFactory()->createMessageFromArray(Command::CALL_EXTERNAL_SERVICE, [
+            UserDescription::IDENTIFIER => $userId,
+        ]);
+
+        $commandProcessor($callExternalService);
+
+        self::assertCount(1, $recordedEvents);
+        /** @var GenericJsonSchemaEvent $event */
+        $event = $recordedEvents[0];
+        self::assertEquals(Event::EXTERNAL_SERVICE_WAS_CALLED, $event->messageName());
+        self::assertEquals([
+            UserDescription::IDENTIFIER => $userId,
+            'dataFromExternalService' => [
+                UserDescription::IDENTIFIER => $userId,
+                'test' => 'succeeded'
+            ]
         ], $event->payload());
     }
 }

--- a/tests/Commanding/CommandToProcessorRouterTest.php
+++ b/tests/Commanding/CommandToProcessorRouterTest.php
@@ -22,6 +22,7 @@ use Prooph\EventStore\EventStore;
 use Prooph\ServiceBus\MessageBus;
 use Prooph\SnapshotStore\SnapshotStore;
 use Prophecy\Argument;
+use Psr\Container\ContainerInterface;
 
 final class CommandToProcessorRouterTest extends BasicTestCase
 {
@@ -38,6 +39,7 @@ final class CommandToProcessorRouterTest extends BasicTestCase
                 'aggregateIdentifier' => 'id',
                 'aggregateFunction' => function () {
                 },
+                'servicesToInject' => [],
                 'eventRecorderMap' => [],
                 'streamName' => 'event_stream',
                 'contextProvider' => 'TestContextProvider',
@@ -53,6 +55,7 @@ final class CommandToProcessorRouterTest extends BasicTestCase
             ],
         ];
 
+        $container = $this->prophesize(ContainerInterface::class);
         $messageFactory = $this->prophesize(MessageFactory::class);
         $eventStore = $this->prophesize(EventStore::class);
         $snapshotStore = $this->prophesize(SnapshotStore::class);
@@ -61,6 +64,7 @@ final class CommandToProcessorRouterTest extends BasicTestCase
         $contextProviderFactory->build(Argument::exact('TestContextProvider'))->willReturn($contextProvider->reveal())->shouldBeCalled();
 
         $router = new CommandToProcessorRouter(
+            $container->reveal(),
             $commandMap,
             $aggregateDescriptions,
             $messageFactory->reveal(),

--- a/tests/EventMachineTest.php
+++ b/tests/EventMachineTest.php
@@ -18,6 +18,7 @@ use Prooph\EventMachine\Container\EventMachineContainer;
 use Prooph\EventMachine\Eventing\GenericJsonSchemaEvent;
 use Prooph\EventMachine\EventMachine;
 use Prooph\EventMachine\JsonSchema\JsonSchema;
+use Prooph\EventMachine\JsonSchema\Type\ArrayType;
 use Prooph\EventMachine\JsonSchema\Type\EmailType;
 use Prooph\EventMachine\JsonSchema\Type\EnumType;
 use Prooph\EventMachine\JsonSchema\Type\StringType;
@@ -510,12 +511,14 @@ class EventMachineTest extends BasicTestCase
 
         $username = (new StringType())->withMinLength(1);
 
+        $dataFromExternalService = new ArrayType(new StringType());
+
         $userDataSchema = JsonSchema::object([
             UserDescription::IDENTIFIER => $userId,
             UserDescription::USERNAME => $username,
             UserDescription::EMAIL => new EmailType(),
         ], [
-            'shouldFail' => JsonSchema::boolean(),
+            'shouldFail' => JsonSchema::boolean()
         ]);
 
         $filterInput = JsonSchema::object([
@@ -533,6 +536,9 @@ class EventMachineTest extends BasicTestCase
                 Command::DO_NOTHING => JsonSchema::object([
                     UserDescription::IDENTIFIER => $userId,
                 ])->toArray(),
+                Command::CALL_EXTERNAL_SERVICE => JsonSchema::object([
+                    UserDescription::IDENTIFIER => $userId,
+                ])->toArray(),
             ],
             'events' => [
                 Event::USER_WAS_REGISTERED => $userDataSchema->toArray(),
@@ -543,6 +549,10 @@ class EventMachineTest extends BasicTestCase
                 ])->toArray(),
                 Event::USER_REGISTRATION_FAILED => JsonSchema::object([
                     UserDescription::IDENTIFIER => $userId,
+                ])->toArray(),
+                Event::EXTERNAL_SERVICE_WAS_CALLED => JsonSchema::object([
+                    UserDescription::IDENTIFIER => $userId,
+                    UserDescription::DATA_FROM_EXTERNAL_SERVICE => $dataFromExternalService
                 ])->toArray(),
             ],
             'queries' => [
@@ -571,6 +581,8 @@ class EventMachineTest extends BasicTestCase
         $userId = new UuidType();
 
         $username = (new StringType())->withMinLength(1);
+
+        $dataFromExternalService = new ArrayType(new StringType());
 
         $userDataSchema = JsonSchema::object([
             UserDescription::IDENTIFIER => $userId,
@@ -614,6 +626,9 @@ class EventMachineTest extends BasicTestCase
                     Command::DO_NOTHING => JsonSchema::object([
                         UserDescription::IDENTIFIER => $userId,
                     ])->toArray(),
+                    Command::CALL_EXTERNAL_SERVICE => JsonSchema::object([
+                        UserDescription::IDENTIFIER => $userId,
+                    ])->toArray(),
                 ],
                 'events' => [
                     Event::USER_WAS_REGISTERED => $userDataSchema->toArray(),
@@ -625,6 +640,10 @@ class EventMachineTest extends BasicTestCase
                     Event::USER_REGISTRATION_FAILED => JsonSchema::object([
                         UserDescription::IDENTIFIER => $userId,
                     ])->toArray(),
+                    Event::EXTERNAL_SERVICE_WAS_CALLED => JsonSchema::object([
+                        UserDescription::IDENTIFIER => $userId,
+                        UserDescription::DATA_FROM_EXTERNAL_SERVICE => $dataFromExternalService
+                    ])->toArray()
                 ],
                 'queries' => $queries,
             ],

--- a/tests/EventMachineTest.php
+++ b/tests/EventMachineTest.php
@@ -518,7 +518,7 @@ class EventMachineTest extends BasicTestCase
             UserDescription::USERNAME => $username,
             UserDescription::EMAIL => new EmailType(),
         ], [
-            'shouldFail' => JsonSchema::boolean()
+            'shouldFail' => JsonSchema::boolean(),
         ]);
 
         $filterInput = JsonSchema::object([
@@ -552,7 +552,7 @@ class EventMachineTest extends BasicTestCase
                 ])->toArray(),
                 Event::EXTERNAL_SERVICE_WAS_CALLED => JsonSchema::object([
                     UserDescription::IDENTIFIER => $userId,
-                    UserDescription::DATA_FROM_EXTERNAL_SERVICE => $dataFromExternalService
+                    UserDescription::DATA_FROM_EXTERNAL_SERVICE => $dataFromExternalService,
                 ])->toArray(),
             ],
             'queries' => [
@@ -642,8 +642,8 @@ class EventMachineTest extends BasicTestCase
                     ])->toArray(),
                     Event::EXTERNAL_SERVICE_WAS_CALLED => JsonSchema::object([
                         UserDescription::IDENTIFIER => $userId,
-                        UserDescription::DATA_FROM_EXTERNAL_SERVICE => $dataFromExternalService
-                    ])->toArray()
+                        UserDescription::DATA_FROM_EXTERNAL_SERVICE => $dataFromExternalService,
+                    ])->toArray(),
                 ],
                 'queries' => $queries,
             ],


### PR DESCRIPTION
As discussed with @sandrokeil this PR is a proposal for solving the issue with injecting services into CommandProcessorDescription::handle() function. As of now you can either do the interaction with the service inside a ProcessManager which would take the logic out of the aggregate, or you could inject the service through event metadata which is rather ugly. This PR implements the ability to add an array of services as a second optional parameter to the CommandProcessorDescription::handle() function:
```
        $eventMachine->process(Command::CALL_EXTERNAL_SERVICE)
            ->withExisting(Aggregate::USER)
            ->handle([CachableUserFunction::class, 'callExternalService'], [ExternalServiceClient::class])
            ->recordThat(Event::EXTERNAL_SERVICE_WAS_CALLED)
            ->apply([CachableUserFunction::class, 'whenExternalServiceWasCalled']);

        public static function callExternalService(UserState $user, Message $callExternalService, ExternalServiceClient $client) 
        {
        }
```
As mentioned this is only a proposal for solving this problem. If anyone has a better idea I'd like to discuss it.