### PR TITLE
Changed return types of the AnnotatedType methods

### DIFF
--- a/src/JsonSchema/AnnotatedType.php
+++ b/src/JsonSchema/AnnotatedType.php
@@ -13,7 +13,7 @@ namespace Prooph\EventMachine\JsonSchema;
 
 interface AnnotatedType extends Type
 {
-    public function entitled(string $title): self;
+    public function entitled(string $title);
 
-    public function describedAs(string $title): self;
+    public function describedAs(string $description);
 }

--- a/src/JsonSchema/Type/HasAnnotations.php
+++ b/src/JsonSchema/Type/HasAnnotations.php
@@ -25,7 +25,7 @@ trait HasAnnotations
      */
     protected $description;
 
-    public function entitled(string $title): AnnotatedType
+    public function entitled(string $title): self
     {
         $cp = clone $this;
 
@@ -39,7 +39,7 @@ trait HasAnnotations
         return $this->title;
     }
 
-    public function describedAs(string $description): AnnotatedType
+    public function describedAs(string $description): self
     {
         $cp = clone $this;
 

--- a/src/JsonSchema/Type/HasAnnotations.php
+++ b/src/JsonSchema/Type/HasAnnotations.php
@@ -11,8 +11,6 @@ declare(strict_types=1);
 
 namespace Prooph\EventMachine\JsonSchema\Type;
 
-use Prooph\EventMachine\JsonSchema\AnnotatedType;
-
 trait HasAnnotations
 {
     /**


### PR DESCRIPTION
PhpStorm complains about the returnType of `AnnotatedType::entitled` and `AnnotatedType::describedAs` being of type `AnnotatedType` insetad of `ObjectType`.
![annotated-type-return-type-issue](https://user-images.githubusercontent.com/25640275/39183671-13fb7394-47c1-11e8-925d-eb7d45f7d34a.png)
This is correct behavior from PhpStorm since `EventMachine::registerCommand()` expects `ObjectType` as the second argument and not `AnnotatedType` which is hinted as the return type of both functions mentioned above. This PR makes slight adjustments to the return types in order to fix this issue. 
Note: I'm not aware of any way to hint the class implementing a given interface (eg. `public function entitled(string $title): static`) so those type hints had to be removed.
