### PR TITLE
Fixed bug where fromInt would be called on a VO that has fromFloat

### DIFF
--- a/src/Data/ImmutableRecordLogic.php
+++ b/src/Data/ImmutableRecordLogic.php
@@ -293,7 +293,9 @@ trait ImmutableRecordLogic
             case 'string':
                 return $type::fromString($value);
             case 'integer':
-                return $type::fromInt($value);
+                return \method_exists($type, 'fromInt')
+                    ? $type::fromInt($value)
+                    : $type::fromFloat($value);
             case 'float':
             case 'double':
                 return $type::fromFloat($value);

--- a/tests/Data/ImmutableRecordTest.php
+++ b/tests/Data/ImmutableRecordTest.php
@@ -198,7 +198,7 @@ final class ImmutableRecordTest extends TestCase
     {
         $productPrice = TestProductPriceVO::fromArray([
             'amount' => 2.0,
-            'currency' => 'EUR'
+            'currency' => 'EUR',
         ]);
 
         $amount = $productPrice->toArray()['amount'];

--- a/tests/Data/ImmutableRecordTest.php
+++ b/tests/Data/ImmutableRecordTest.php
@@ -18,6 +18,7 @@ use Prooph\EventMachineTest\Data\Stubs\TestCommentVO;
 use Prooph\EventMachineTest\Data\Stubs\TestDefaultPrice;
 use Prooph\EventMachineTest\Data\Stubs\TestIdentityVO;
 use Prooph\EventMachineTest\Data\Stubs\TestProduct;
+use Prooph\EventMachineTest\Data\Stubs\TestProductPriceVO;
 use Prooph\EventMachineTest\Data\Stubs\TestProductVO;
 use Prooph\EventMachineTest\Data\Stubs\TestUserVO;
 
@@ -188,5 +189,28 @@ final class ImmutableRecordTest extends TestCase
         $defaultPrice = TestDefaultPrice::fromArray([]);
 
         $this->assertEquals(['amount' => 9.99, 'currency' => 'EUR'], $defaultPrice->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function it_calls_from_float_when_from_int_does_not_exist()
+    {
+        $productPrice = TestProductPriceVO::fromArray([
+            'amount' => 2.0,
+            'currency' => 'EUR'
+        ]);
+
+        $amount = $productPrice->toArray()['amount'];
+        $this->assertEquals(2.0, $amount);
+        $this->assertInternalType('float', $amount);
+
+        $json = json_encode($productPrice->toArray());
+        $this->assertEquals('{"amount":2,"currency":"EUR"}', $json);
+
+        $productPrice = TestProductPriceVO::fromArray(json_decode($json, true));
+        $amount = $productPrice->toArray()['amount'];
+        $this->assertEquals(2.0, $amount);
+        $this->assertInternalType('float', $amount);
     }
 }


### PR DESCRIPTION
https://github.com/proophsoftware/event-machine/issues/94

Was wondering why caling `fromFloat()` with an integer wouldn't result in a type error, found this in the docs: In strict mode, only a variable of exact type of the type declaration will be accepted, or a TypeError will be thrown. The only exception to this rule is that an integer may be given to a function expecting a float