### PR TITLE
Fix: Use array prop item type map in ImmutableRecordLogic from/to array

### DIFF
--- a/src/Data/ImmutableRecord.php
+++ b/src/Data/ImmutableRecord.php
@@ -15,6 +15,12 @@ use Prooph\EventMachine\JsonSchema\Type;
 
 interface ImmutableRecord
 {
+    const PHP_TYPE_STRING = 'string';
+    const PHP_TYPE_INT = 'int';
+    const PHP_TYPE_FLOAT = 'float';
+    const PHP_TYPE_BOOL = 'bool';
+    const PHP_TYPE_ARRAY = 'array';
+
     /**
      * Name of the immutable record type
      *

--- a/tests/Data/ImmutableRecordTest.php
+++ b/tests/Data/ImmutableRecordTest.php
@@ -13,6 +13,8 @@ namespace Prooph\EventMachineTest\Data;
 
 use PHPUnit\Framework\TestCase;
 use Prooph\EventMachine\JsonSchema\JsonSchema;
+use Prooph\EventMachineTest\Data\Stubs\TestBlacklistIdentityCollectionVO;
+use Prooph\EventMachineTest\Data\Stubs\TestBlacklistVO;
 use Prooph\EventMachineTest\Data\Stubs\TestBuildingVO;
 use Prooph\EventMachineTest\Data\Stubs\TestCommentVO;
 use Prooph\EventMachineTest\Data\Stubs\TestDefaultPrice;
@@ -22,7 +24,7 @@ use Prooph\EventMachineTest\Data\Stubs\TestProductPriceVO;
 use Prooph\EventMachineTest\Data\Stubs\TestProductVO;
 use Prooph\EventMachineTest\Data\Stubs\TestUserVO;
 
-final class ImmutableRecordTest extends TestCase
+class ImmutableRecordTest extends TestCase
 {
     /**
      * @test
@@ -146,8 +148,10 @@ final class ImmutableRecordTest extends TestCase
             'name' => 'Alex',
             'age' => null,
             'identities' => [
-                'email' => 'contact@prooph.de',
-                'password' => 'dev1234',
+                [
+                    'email' => 'contact@prooph.de',
+                    'password' => 'dev1234',
+                ],
             ],
         ];
 
@@ -212,5 +216,71 @@ final class ImmutableRecordTest extends TestCase
         $amount = $productPrice->toArray()['amount'];
         $this->assertEquals(2.0, $amount);
         $this->assertInternalType('float', $amount);
+    }
+
+    /**
+     * @test
+     */
+    public function it_respects_schema_array_item_type_hint_when_mapping_from_and_to_array()
+    {
+        $data = [
+            'id' => '1',
+            'name' => 'Alex',
+            'age' => null,
+            'identities' => [
+                [
+                    'email' => 'contact@prooph.de',
+                    'password' => 'dev1234',
+                ],
+            ],
+        ];
+
+        $testUser = TestUserVO::fromArray($data);
+
+        $this->assertInstanceOf(TestIdentityVO::class, $testUser->identities()[0]);
+
+        $this->assertEquals($data, $testUser->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function it_respects_array_item_type_hint_method_when_mapping_from_and_to_array()
+    {
+        $data = [
+            'identities' => [
+                [
+                    'email' => 'contact@prooph.de',
+                    'password' => 'dev1234',
+                ],
+            ],
+        ];
+
+        $blacklist = TestBlacklistVO::fromArray($data);
+
+        $this->assertInstanceOf(TestIdentityVO::class, $blacklist->identities()[0]);
+
+        $this->assertEquals($data, $blacklist->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function it_uses_collection_vo_when_mapping_from_and_to_array()
+    {
+        $data = [
+            'identities' => [
+                [
+                    'email' => 'contact@prooph.de',
+                    'password' => 'dev1234',
+                ],
+            ],
+        ];
+
+        $blacklist = TestBlacklistIdentityCollectionVO::fromArray($data);
+
+        $this->assertInstanceOf(TestIdentityVO::class, $blacklist->identities()->first());
+
+        $this->assertEquals($data, $blacklist->toArray());
     }
 }

--- a/tests/Data/Stubs/TestBlacklistIdentityCollectionVO.php
+++ b/tests/Data/Stubs/TestBlacklistIdentityCollectionVO.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This file is part of the proophsoftware/event-machine.
+ * (c) 2017-2018 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventMachineTest\Data\Stubs;
+
+use Prooph\EventMachine\Data\ImmutableRecord;
+use Prooph\EventMachine\Data\ImmutableRecordLogic;
+
+final class TestBlacklistIdentityCollectionVO implements ImmutableRecord
+{
+    use ImmutableRecordLogic;
+
+    /**
+     * @var TestIdentityCollectionVO
+     */
+    private $identities;
+
+    /**
+     * @return TestIdentityCollectionVO
+     */
+    public function identities(): TestIdentityCollectionVO
+    {
+        return $this->identities;
+    }
+}

--- a/tests/Data/Stubs/TestBlacklistVO.php
+++ b/tests/Data/Stubs/TestBlacklistVO.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * This file is part of the proophsoftware/event-machine.
+ * (c) 2017-2018 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventMachineTest\Data\Stubs;
+
+use Prooph\EventMachine\Data\ImmutableRecord;
+use Prooph\EventMachine\Data\ImmutableRecordLogic;
+
+final class TestBlacklistVO implements ImmutableRecord
+{
+    use ImmutableRecordLogic;
+
+    private static function arrayPropItemTypeMap(): array
+    {
+        return [
+            'identities' => TestIdentityVO::class,
+        ];
+    }
+
+    /**
+     * @var TestIdentityVO[]
+     */
+    private $identities;
+
+    /**
+     * @return TestIdentityVO[]
+     */
+    public function identities(): array
+    {
+        return $this->identities;
+    }
+}

--- a/tests/Data/Stubs/TestIdentityCollectionVO.php
+++ b/tests/Data/Stubs/TestIdentityCollectionVO.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This file is part of the proophsoftware/event-machine.
+ * (c) 2017-2018 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventMachineTest\Data\Stubs;
+
+final class TestIdentityCollectionVO
+{
+    /**
+     * @var TestIdentityVO[]
+     */
+    private $identities;
+
+    public static function fromIdentities(TestIdentityVO ...$identities): self
+    {
+        return new self(...$identities);
+    }
+
+    public static function fromArray(array $data): self
+    {
+        $identities = array_map(function ($item) {
+            return TestIdentityVO::fromArray($item);
+        }, $data);
+
+        return new self(...$identities);
+    }
+
+    private function __construct(TestIdentityVO ...$identities)
+    {
+        $this->identities = $identities;
+    }
+
+    public function first(): TestIdentityVO
+    {
+        return $this->identities[0];
+    }
+
+    public function toArray(): array
+    {
+        return array_map(function (TestIdentityVO $item) {
+            return $item->toArray();
+        }, $this->identities);
+    }
+
+    public function equals($other): bool
+    {
+        if (! $other instanceof self) {
+            return false;
+        }
+
+        return $this->toArray() === $other->toArray();
+    }
+
+    public function __toString(): string
+    {
+        return json_encode($this->toArray());
+    }
+}

--- a/tests/Data/Stubs/TestProduct.php
+++ b/tests/Data/Stubs/TestProduct.php
@@ -13,12 +13,17 @@ namespace Prooph\EventMachineTest\Data\Stubs;
 
 use Prooph\EventMachine\Data\ImmutableRecord;
 use Prooph\EventMachine\Data\ImmutableRecordLogic;
-use Prooph\EventMachine\JsonSchema\JsonSchema;
-use Prooph\EventMachine\JsonSchema\Type;
 
 final class TestProduct implements ImmutableRecord
 {
     use ImmutableRecordLogic;
+
+    private static function arrayPropItemTypeMap(): array
+    {
+        return [
+            'tags' => ImmutableRecord::PHP_TYPE_STRING,
+        ];
+    }
 
     /**
      * @var int
@@ -49,11 +54,6 @@ final class TestProduct implements ImmutableRecord
      * @var array
      */
     private $tags;
-
-    public static function __schema(): Type
-    {
-        return self::generateSchemaFromPropTypeMap(['tags' => JsonSchema::TYPE_STRING]);
-    }
 
     /**
      * @return int

--- a/tests/Data/Stubs/TestProductVO.php
+++ b/tests/Data/Stubs/TestProductVO.php
@@ -18,6 +18,11 @@ final class TestProductVO implements ImmutableRecord
 {
     use ImmutableRecordLogic;
 
+    private static function arrayPropItemTypeMap(): array
+    {
+        return ['tags' => ImmutableRecord::PHP_TYPE_STRING];
+    }
+
     /**
      * @var TestProductIdVO
      */


### PR DESCRIPTION
Fixes #91 

**Attention! Before this fix it was possible to have an array property in an immutable record without providing an array item type hint. It worked when the array property only contain scalar items. WITH THIS PR YOU ALWAYS HAVE TO PROVIDE A TYPE HINT FOR AN ARRAY PROPERTY**

Check the `State` record class of the tutorial: https://proophsoftware.github.io/event-machine/tutorial/partVI.html#2-7-3

```php
public static function __schema(): Type
    {
        return self::generateSchemaFromPropTypeMap([
            'users' => ImmutableRecord::PHP_TYPE_STRING
        ]);
    }
```
That's the old way ^^, which still works and here is the recommended new way introduced by this PR!:

```php
private static function arrayPropItemTypeMap(): array
 {
    return [
        'users' => ImmutableRecord::PHP_TYPE_STRING
   ];
}
```